### PR TITLE
Changes behavior when not printing to a tty

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"os"
 	"strings"
+
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 // DrawFunc is the callback type for drawing progress.
@@ -18,6 +20,14 @@ var defaultDrawFunc DrawFunc
 
 func init() {
 	defaultDrawFunc = DrawTerminal(os.Stdout)
+}
+
+// isTerminal returns True when w is going to a tty, and false otherwise.
+func isTerminal(w io.Writer) bool {
+	if f, ok := w.(*os.File); ok {
+		return terminal.IsTerminal(int(f.Fd()))
+	}
+	return false
 }
 
 // DrawTerminal returns a DrawFunc that draws a progress bar to an io.Writer
@@ -50,7 +60,11 @@ func DrawTerminalf(w io.Writer, f DrawTextFormatFunc) DrawFunc {
 		}
 		maxLength = len(line)
 
-		_, err := fmt.Fprint(w, line+"\r")
+		terminate := "\r"
+		if !isTerminal(w) {
+			terminate = "\n"
+		}
+		_, err := fmt.Fprint(w, line+terminate)
 		return err
 	}
 }
@@ -77,6 +91,19 @@ func DrawTextFormatBytes(progress, total int64) string {
 //     }
 //
 func DrawTextFormatBar(width int64) DrawTextFormatFunc {
+	return DrawTextFormatBarForW(width, nil)
+}
+
+// DrawTextFormatBarForW returns a DrawTextFormatFunc as described in the docs
+// for DrawTextFormatBar, however if the io.Writer passed in is not a tty then
+// the returned function will always return "".
+func DrawTextFormatBarForW(width int64, w io.Writer) DrawTextFormatFunc {
+	if w != nil && !isTerminal(w) {
+		return func(progress, total int64) string {
+			return ""
+		}
+	}
+
 	width -= 2
 
 	return func(progress, total int64) string {


### PR DESCRIPTION
Successive updates to the download progress will not print over each other when not printing to a tty. Instead they will print to new lines.

I was also going to not draw the bar when not printing to a tty, but the `io.Writer` isn't known by ioprogress when the bar draw function is generated.

When invoked in `systemd-run` as shown in https://github.com/coreos/rkt/issues/1282, it now looks like:

```
Sep 15 12:03:48 falcon systemd[1]: Started /home/derek/go/src/github.com/coreos/rkt/rkt/./rkt --debug --insecure-skip-verify run docker://redis.
Sep 15 12:03:51 falcon rkt[26364]: rkt: fetching image from docker://redis
Sep 15 12:03:58 falcon rkt[26364]: Downloading ba249489d0b6: [                                    ] 0 B/37.2 MB
Sep 15 12:03:58 falcon rkt[26364]: Downloading ba249489d0b6: [                                    ] 3.59 KB/37.2 MB
Sep 15 12:03:59 falcon rkt[26364]: Downloading ba249489d0b6: [=                                   ] 1.54 MB/37.2 MB
Sep 15 12:03:59 falcon rkt[26364]: Downloading ba249489d0b6: [===                                 ] 3.37 MB/37.2 MB
Sep 15 12:04:00 falcon rkt[26364]: Downloading ba249489d0b6: [=====                               ] 5.43 MB/37.2 MB
Sep 15 12:04:00 falcon rkt[26364]: Downloading ba249489d0b6: [=======                             ] 7.45 MB/37.2 MB
Sep 15 12:04:01 falcon rkt[26364]: Downloading ba249489d0b6: [=========                           ] 9.69 MB/37.2 MB
Sep 15 12:04:01 falcon rkt[26364]: Downloading ba249489d0b6: [===========                         ] 11.4 MB/37.2 MB
Sep 15 12:04:02 falcon rkt[26364]: Downloading ba249489d0b6: [=============                       ] 13.6 MB/37.2 MB
Sep 15 12:04:02 falcon rkt[26364]: Downloading ba249489d0b6: [==============                      ] 15.2 MB/37.2 MB
Sep 15 12:04:03 falcon rkt[26364]: Downloading ba249489d0b6: [================                    ] 16.7 MB/37.2 MB
Sep 15 12:04:03 falcon rkt[26364]: Downloading ba249489d0b6: [=================                   ] 18.3 MB/37.2 MB
Sep 15 12:04:04 falcon rkt[26364]: Downloading ba249489d0b6: [===================                 ] 19.9 MB/37.2 MB
Sep 15 12:04:04 falcon rkt[26364]: Downloading ba249489d0b6: [====================                ] 21.4 MB/37.2 MB
Sep 15 12:04:05 falcon rkt[26364]: Downloading ba249489d0b6: [=====================               ] 22.1 MB/37.2 MB
Sep 15 12:04:05 falcon rkt[26364]: Downloading ba249489d0b6: [======================              ] 23.6 MB/37.2 MB
Sep 15 12:04:06 falcon rkt[26364]: Downloading ba249489d0b6: [========================            ] 24.8 MB/37.2 MB
Sep 15 12:04:06 falcon rkt[26364]: Downloading ba249489d0b6: [=========================           ] 26 MB/37.2 MB
Sep 15 12:04:07 falcon rkt[26364]: Downloading ba249489d0b6: [==========================          ] 27.4 MB/37.2 MB
Sep 15 12:04:07 falcon rkt[26364]: Downloading ba249489d0b6: [============================        ] 29 MB/37.2 MB
Sep 15 12:04:08 falcon rkt[26364]: Downloading ba249489d0b6: [=============================       ] 30.2 MB/37.2 MB
Sep 15 12:04:08 falcon rkt[26364]: Downloading ba249489d0b6: [==============================      ] 31.1 MB/37.2 MB
Sep 15 12:04:09 falcon rkt[26364]: Downloading ba249489d0b6: [==============================      ] 31.9 MB/37.2 MB
Sep 15 12:04:09 falcon rkt[26364]: Downloading ba249489d0b6: [===============================     ] 32.9 MB/37.2 MB
Sep 15 12:04:10 falcon rkt[26364]: Downloading ba249489d0b6: [================================    ] 34.1 MB/37.2 MB
Sep 15 12:04:10 falcon rkt[26364]: Downloading ba249489d0b6: [==================================  ] 35.2 MB/37.2 MB
Sep 15 12:04:11 falcon rkt[26364]: Downloading ba249489d0b6: [=================================== ] 36.4 MB/37.2 MB
Sep 15 12:04:11 falcon rkt[26364]: Downloading ba249489d0b6: [====================================] 37.2 MB/37.2 MB
Sep 15 12:04:15 falcon rkt[26364]: Downloading 19de96c112fc: [                                    ] 0 B/32 B
Sep 15 12:04:15 falcon rkt[26364]: Downloading 19de96c112fc: [====================================] 32 B/32 B
Sep 15 12:04:15 falcon rkt[26364]: Downloading d990a769a35e: [                                    ] 0 B/1.7 KB
Sep 15 12:04:15 falcon rkt[26364]: Downloading d990a769a35e: [====================================] 1.7 KB/1.7 KB
Sep 15 12:04:16 falcon rkt[26364]: Downloading 8656a511ce9c: [                                    ] 0 B/5.94 MB
Sep 15 12:04:16 falcon rkt[26364]: Downloading 8656a511ce9c: [                                    ] 16.4 KB/5.94 MB
Sep 15 12:04:17 falcon rkt[26364]: Downloading 8656a511ce9c: [=========                           ] 1.53 MB/5.94 MB
Sep 15 12:04:17 falcon rkt[26364]: Downloading 8656a511ce9c: [====================                ] 3.34 MB/5.94 MB
Sep 15 12:04:18 falcon rkt[26364]: Downloading 8656a511ce9c: [====================================] 5.94 MB/5.94 MB
Sep 15 12:04:19 falcon rkt[26364]: Downloading f7022ac152fb: [                                    ] 0 B/93.6 KB
Sep 15 12:04:19 falcon rkt[26364]: Downloading f7022ac152fb: [=                                   ] 3.59 KB/93.6 KB
Sep 15 12:04:19 falcon rkt[26364]: Downloading f7022ac152fb: [====================================] 93.6 KB/93.6 KB
Sep 15 12:04:19 falcon rkt[26364]: Downloading 8e84d9ce7554: [                                    ] 0 B/611 KB
Sep 15 12:04:19 falcon rkt[26364]: Downloading 8e84d9ce7554: [                                    ] 3.59 KB/611 KB
Sep 15 12:04:20 falcon rkt[26364]: Downloading 8e84d9ce7554: [====================================] 611 KB/611 KB
Sep 15 12:04:20 falcon rkt[26364]: Downloading c9e5dd2a9302: [                                    ] 0 B/32 B
Sep 15 12:04:20 falcon rkt[26364]: Downloading c9e5dd2a9302: [====================================] 32 B/32 B
Sep 15 12:04:21 falcon rkt[26364]: Downloading 27b967cdd519: [                                    ] 0 B/32 B
Sep 15 12:04:21 falcon rkt[26364]: Downloading 27b967cdd519: [====================================] 32 B/32 B
Sep 15 12:04:21 falcon rkt[26364]: Downloading 3024bf5093a1: [                                    ] 0 B/32 B
Sep 15 12:04:21 falcon rkt[26364]: Downloading 3024bf5093a1: [====================================] 32 B/32 B
```
