### PR TITLE
DrawTextFormatBar: nonsensical numbers could cause a panic

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -108,6 +108,9 @@ func DrawTextFormatBarForW(width int64, w io.Writer) DrawTextFormatFunc {
 
 	return func(progress, total int64) string {
 		current := int64((float64(progress) / float64(total)) * float64(width))
+		if current < 0 || current > width {
+			return fmt.Sprintf("[%s]", strings.Repeat(" ", int(width)))
+		}
 		return fmt.Sprintf(
 			"[%s%s]",
 			strings.Repeat("=", int(current)),

--- a/draw_test.go
+++ b/draw_test.go
@@ -44,6 +44,24 @@ func TestDrawTextFormatBar(t *testing.T) {
 	if actual != expected {
 		t.Fatalf("bad: %s", actual)
 	}
+
+	actual = f(0, 0)
+	expected = "[        ]"
+	if actual != expected {
+		t.Fatalf("bad: %s", actual)
+	}
+
+	actual = f(-10, 10)
+	expected = "[        ]"
+	if actual != expected {
+		t.Fatalf("bad: %s", actual)
+	}
+
+	actual = f(20, 10)
+	expected = "[        ]"
+	if actual != expected {
+		t.Fatalf("bad: %s", actual)
+	}
 }
 
 func TestDrawTextFormatBytes(t *testing.T) {

--- a/draw_test.go
+++ b/draw_test.go
@@ -69,4 +69,4 @@ func TestDrawTextFormatBytes(t *testing.T) {
 	}
 }
 
-const drawTerminalStr = "0/100\r20/100\r\n"
+const drawTerminalStr = "0/100\n20/100\n\n"

--- a/reader_test.go
+++ b/reader_test.go
@@ -31,7 +31,7 @@ func TestReader(t *testing.T) {
 	}
 }
 
-const drawReaderStr = "0/6\r2/6\r4/6\r6/6\r6/6\r\n"
+const drawReaderStr = "0/6\n2/6\n4/6\n6/6\n6/6\n\n"
 
 // testReader is a test structure to help with testing the Reader by
 // returning fixed slices of data.


### PR DESCRIPTION
If one of the numbers provided to draw the progress bar was nonsensical,
like the total download size being 0, ioprogress would cause a panic.

This adds a check for a unexpected current progress, and will display an
empty bar if it's outside acceptable bounds.
