### PR TITLE
tests: expected output has changed, broke tests

### DIFF
--- a/draw_test.go
+++ b/draw_test.go
@@ -69,4 +69,4 @@ func TestDrawTextFormatBytes(t *testing.T) {
 	}
 }
 
-const drawTerminalStr = "0/100\r20/100\r\n"
+const drawTerminalStr = "0/100\n20/100\n\n"

--- a/reader_test.go
+++ b/reader_test.go
@@ -31,7 +31,7 @@ func TestReader(t *testing.T) {
 	}
 }
 
-const drawReaderStr = "0/6\r2/6\r4/6\r6/6\r6/6\r\n"
+const drawReaderStr = "0/6\n2/6\n4/6\n6/6\n6/6\n\n"
 
 // testReader is a test structure to help with testing the Reader by
 // returning fixed slices of data.


### PR DESCRIPTION
With a recent change ioprogress now checks if it's printing to a
terminal and will use "\n" instead of "\r" if it is not. The tests were
expecting ioprogress to print "\r"s, but since ioprogress is not
printing to a terminal that was no longer the case
